### PR TITLE
Use rawset to avoid warnings

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -40,7 +40,7 @@ require 'math'
 require 'torch'
 
 -- remember startup variables (to protect them)
-_G._protect_ = {'_protect_','xlua'}
+rawset(_G, '_protect_',{'_protect_','xlua'})
 for k,v in pairs(_G) do
    table.insert(_G._protect_, k)
 end
@@ -115,7 +115,7 @@ print = function(obj,...)
               glob.io.write('\n')
            end
         end
-glob.xprint = print
+glob.rawset(glob, 'xprint', print)
 
 ----------------------------------------------------------------------
 -- log all session, by replicating stdout to a file
@@ -310,7 +310,7 @@ function error(message, domain, usage)
    end
    glob.error(col_msg)
 end
-glob.xerror = error
+glob.rawset(glob, 'xerror', error)
 
 --------------------------------------------------------------------------------
 -- provides standard try/catch functions
@@ -356,7 +356,7 @@ function require(package,luarocks,server)
    end
    return loaded
 end
-glob.xrequire = require
+glob.rawset(glob, 'xrequire', require)
 
 --------------------------------------------------------------------------------
 -- standard usage function: used to display automated help for functions


### PR DESCRIPTION
I suggest to use rawset instead of directly setting the globals protect, xprint, xerror and xrequire.

This avoids warnings when using a strictness package (e.g. [strict](https://github.com/deepmind/strict)) which prevents write access to undeclared globals by modifying the _G metatable.