### PR TITLE
Limit progress bar length

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -236,7 +236,7 @@ do
    local timer
    local times
    local indices
-   local termLength = getTermLength()
+   local termLength = math.min(getTermLength(), 120)
    function xlua.progress(current, goal)
       -- defaults:
       local barLength = termLength - 34


### PR DESCRIPTION
this was annoying me for some time. max term length should be limited
before:
```
th> for i=1,1000 do xlua.progress(i,1000) end
 [========================================================================================================================================= 1000/1000 =======================================================================================================================================>]ETA: 0ms | Step: 0ms
```
after:
```
th> for i=1,1000 do xlua.progress(i,1000) end
 [======================================= 1000/1000 ===================================>] ETA: 0ms | Step: 0ms
```