### PR TITLE
Adding prefix title to progressbar and adjusting width of progressbar accordingly

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -237,11 +237,11 @@ do
    local times
    local indices
    local termLength = math.min(getTermLength(), 120)
-   function xlua.progress(current, goal, title)
+   function xlua.progress(current, goal, prefix)
       -- sanity check
-      if title == nil then title = "" else title = tostring(title)..":" end
+      if prefix == nil then prefix = "" else prefix = tostring(prefix)..":" end
       -- defaults:
-      local barLength = termLength - 34 - #title
+      local barLength = termLength - 34 - #prefix
       local smoothing = 100 
       local maxfps = 10
       
@@ -264,7 +264,7 @@ do
       if (not barDone) then
          previous = percent
          -- print bar
-         io.write(title .. ' [')
+         io.write(prefix .. ' [')
          for i=1,barLength do
             if (i < percent) then io.write('=')
             elseif (i == percent) then io.write('>')

--- a/init.lua
+++ b/init.lua
@@ -237,9 +237,11 @@ do
    local times
    local indices
    local termLength = math.min(getTermLength(), 120)
-   function xlua.progress(current, goal)
+   function xlua.progress(current, goal, title)
+      -- sanity check
+      if title == nil then title = "" else title = tostring(title)..":" end
       -- defaults:
-      local barLength = termLength - 34
+      local barLength = termLength - 34 - #title
       local smoothing = 100 
       local maxfps = 10
       
@@ -262,7 +264,7 @@ do
       if (not barDone) then
          previous = percent
          -- print bar
-         io.write(' [')
+         io.write(title .. ' [')
          for i=1,barLength do
             if (i < percent) then io.write('=')
             elseif (i == percent) then io.write('>')


### PR DESCRIPTION
Re: https://github.com/torch/xlua/issues/23


xlua.progressbar() currently lacks ability to add a title string as a prefix such as 'training', 'validation' or 'testing'.

Training : [=================== 5306/5306 =================>] Tot: 8m57s | Step: 107ms
Validation : [==================== 100/100 ==================>] Tot: 13s850ms | Step: 164ms

It is a simple fix to concatenate with title and adjust the progressbar width accordingly.